### PR TITLE
Add optional message field to signup requests and update related comp…

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -266,6 +266,7 @@ export default defineSchema({
   signupRequests: defineTable({
     email: v.string(),
     fullName: v.string(),
+    message: v.optional(v.string()),
     phone: v.optional(v.string()),
     status: v.union(v.literal("pending"), v.literal("approved"), v.literal("rejected")),
     reviewedBy: v.optional(v.id("profiles")),

--- a/convex/signupRequests.ts
+++ b/convex/signupRequests.ts
@@ -24,6 +24,7 @@ export const createSignupRequest = mutation({
     const signupRequestId = await ctx.db.insert("signupRequests", {
       email: args.email,
       fullName: args.fullName,
+      message: args.message,
       status: "pending",
     });
 

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -187,7 +187,6 @@ export default function AuthPage() {
         defaultValues: {
             full_name: "",
             email: "",
-            password: "",
             message: "",
         },
     });
@@ -257,6 +256,7 @@ export default function AuthPage() {
                 return await createSignupRequestMutation({
                     fullName: data.full_name,
                     email: data.email,
+                    message: data.message,
                 });
             }
         },


### PR DESCRIPTION
…onents

- Introduced an optional `message` field in the `signupRequests` schema to allow users to provide additional information during signup.
- Updated the `createSignupRequest` mutation to handle the new `message` field.
- Modified the `AuthPage` component to include the `message` field in the form and submission logic, enhancing user input capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signup requests can now include an optional message field.
* **Enhancements**
  * The signup form now allows users to submit an optional message with their signup request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->